### PR TITLE
Bug Fixes

### DIFF
--- a/cmd/memorychat/main.go
+++ b/cmd/memorychat/main.go
@@ -4,8 +4,8 @@ import (
 	"log"
 
 	"github.com/soggycactus/sharechat.dev/sharechat"
+	"github.com/soggycactus/sharechat.dev/sharechat/http"
 	"github.com/soggycactus/sharechat.dev/sharechat/memory"
-	"github.com/soggycactus/sharechat.dev/sharechat/mux"
 )
 
 func main() {
@@ -19,7 +19,7 @@ func main() {
 		Queue:       memory.NewQueue(),
 	})
 
-	server := mux.NewServer(controller)
+	server := http.NewServer(controller)
 
 	log.Print("starting server on port 8080")
 	log.Fatal(server.ListenAndServe())

--- a/cmd/sharechat/main.go
+++ b/cmd/sharechat/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/pressly/goose/v3"
 	"github.com/soggycactus/sharechat.dev/sharechat"
-	"github.com/soggycactus/sharechat.dev/sharechat/mux"
+	"github.com/soggycactus/sharechat.dev/sharechat/http"
 	"github.com/soggycactus/sharechat.dev/sharechat/postgres"
 	"github.com/soggycactus/sharechat.dev/sharechat/redis"
 )
@@ -45,7 +45,7 @@ func main() {
 		Queue:       redis.NewQueue(redisHost, redisUser, redisPass),
 	})
 
-	server := mux.NewServer(controller)
+	server := http.NewServer(controller)
 
 	log.Print("starting server on port 8080")
 	log.Fatal(server.ListenAndServe())

--- a/sharechat/controller.go
+++ b/sharechat/controller.go
@@ -184,13 +184,14 @@ func (c *Controller) Publish(ctx context.Context, member *Member) {
 				}
 				return
 			default:
-				if err := c.messageRepo.InsertMessage(ctx, message); err != nil {
+				result, err := c.messageRepo.InsertMessage(ctx, message)
+				if err != nil {
 					log.Printf("failed to insert message: %v", err)
 					member.inbound <- NewSendFailedMessage(*member)
 					break
 				}
 
-				if err := c.queue.Publish(ctx, message); err != nil {
+				if err := c.queue.Publish(ctx, *result); err != nil {
 					log.Printf("failed to publish message: %v", err)
 				}
 			}

--- a/sharechat/controller_test.go
+++ b/sharechat/controller_test.go
@@ -42,6 +42,8 @@ func TestController(t *testing.T) {
 		WithWriteMessageResult(nil).
 		WithReadBytesResult([]byte("hello world"), nil)
 
+	beforeSent := time.Now()
+
 	err = controller.ServeRoom(ctx, room.ID, connection)
 	if err != nil {
 		t.Fatalf("failed to serve room: %v", err)
@@ -53,4 +55,5 @@ func TestController(t *testing.T) {
 	assert.Equal(t, sharechat.Chat, chat.Type, "second message should be chat type")
 	assert.Equal(t, "hello world", chat.Message, "message content should be equal")
 	assert.Equal(t, 1, len(room.Members()), "room should have one member")
+	assert.True(t, beforeSent.Before(chat.Sent), "message timestamp should be more recent")
 }

--- a/sharechat/http/connection.go
+++ b/sharechat/http/connection.go
@@ -1,4 +1,4 @@
-package mux
+package http
 
 import (
 	"errors"

--- a/sharechat/http/handlers.go
+++ b/sharechat/http/handlers.go
@@ -1,4 +1,4 @@
-package mux
+package http
 
 import (
 	"context"

--- a/sharechat/http/server.go
+++ b/sharechat/http/server.go
@@ -1,4 +1,4 @@
-package mux
+package http
 
 import (
 	"net/http"

--- a/sharechat/memory/member.go
+++ b/sharechat/memory/member.go
@@ -24,11 +24,12 @@ func (m *MemberRepo) InsertMember(ctx context.Context, member sharechat.Member) 
 	m.Members[member.ID] = member
 	message := sharechat.NewMemberJoinedMessage(member)
 	message.Sent = time.Now()
-	if err := m.messageRepo.InsertMessage(ctx, message); err != nil {
+	result, err := m.messageRepo.InsertMessage(ctx, message)
+	if err != nil {
 		delete(m.Members, member.ID)
 		return nil, errors.New("failed to insert member")
 	}
-	return &message, nil
+	return result, nil
 }
 
 func (m *MemberRepo) GetMembersByRoom(ctx context.Context, roomID string) (*[]sharechat.Member, error) {
@@ -46,10 +47,11 @@ func (m *MemberRepo) GetMembersByRoom(ctx context.Context, roomID string) (*[]sh
 func (m *MemberRepo) DeleteMember(ctx context.Context, member sharechat.Member) (*sharechat.Message, error) {
 	message := sharechat.NewMemberLeftMessage(member)
 	message.Sent = time.Now()
-	if err := m.messageRepo.InsertMessage(ctx, message); err != nil {
+	result, err := m.messageRepo.InsertMessage(ctx, message)
+	if err != nil {
 		return nil, errors.New("failed to delete member")
 	}
 	delete(m.Members, member.ID)
 
-	return &message, nil
+	return result, nil
 }

--- a/sharechat/memory/message.go
+++ b/sharechat/memory/message.go
@@ -19,12 +19,12 @@ func NewMessageRepo() *MessageRepo {
 	}
 }
 
-func (m *MessageRepo) InsertMessage(ctx context.Context, message sharechat.Message) error {
+func (m *MessageRepo) InsertMessage(ctx context.Context, message sharechat.Message) (*sharechat.Message, error) {
 	m.mu.Lock()
 	message.Sent = time.Now()
 	m.Messages[message.ID] = message
 	m.mu.Unlock()
-	return nil
+	return &message, nil
 }
 
 func (m *MessageRepo) GetMessagesByRoom(ctx context.Context, roomID string) (*[]sharechat.Message, error) {

--- a/sharechat/message.go
+++ b/sharechat/message.go
@@ -10,7 +10,7 @@ import (
 )
 
 type MessageRepository interface {
-	InsertMessage(ctx context.Context, message Message) error
+	InsertMessage(ctx context.Context, message Message) (*Message, error)
 	GetMessagesByRoom(ctx context.Context, roomID string) (*[]Message, error)
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/gavv/httpexpect"
 	"github.com/pressly/goose/v3"
 	"github.com/soggycactus/sharechat.dev/sharechat"
+	sharechathttp "github.com/soggycactus/sharechat.dev/sharechat/http"
 	"github.com/soggycactus/sharechat.dev/sharechat/memory"
-	"github.com/soggycactus/sharechat.dev/sharechat/mux"
 	"github.com/soggycactus/sharechat.dev/sharechat/postgres"
 	"github.com/soggycactus/sharechat.dev/sharechat/redis"
 )
@@ -129,7 +129,7 @@ func TestMemory(t *testing.T) {
 		Queue:       redis.NewQueue("0.0.0.0:6379", "", ""),
 	})
 
-	server := httptest.NewServer(mux.NewServer(controller).Handler)
+	server := httptest.NewServer(sharechathttp.NewServer(controller).Handler)
 	defer server.Close()
 	e := httpexpect.New(t, server.URL)
 	ServeNewRoom(e)
@@ -159,7 +159,7 @@ func TestServeNewRoom(t *testing.T) {
 		Queue:       redis.NewQueue("0.0.0.0:6379", "", ""),
 	})
 
-	server := httptest.NewServer(mux.NewServer(controller).Handler)
+	server := httptest.NewServer(sharechathttp.NewServer(controller).Handler)
 	defer server.Close()
 	e := httpexpect.New(t, server.URL)
 	ServeNewRoom(e)
@@ -189,7 +189,7 @@ func TestServeExistingRoom(t *testing.T) {
 		Queue:       redis.NewQueue("0.0.0.0:6379", "", ""),
 	})
 
-	server := httptest.NewServer(mux.NewServer(controller).Handler)
+	server := httptest.NewServer(sharechathttp.NewServer(controller).Handler)
 	defer server.Close()
 	e := httpexpect.New(t, server.URL)
 


### PR DESCRIPTION
This PR simplifies shutting down go-routines by safely closing channels in cases where the senders are aware of a shutdown. Go-routines that are senders are still shutdown via a `stopCh`, since closing the channels they send on would cause a panic. I also fixed a bug where message timestamps were persisted in the database, but not on the messages themselves when transmitted over websocket. 