### PR TITLE
multiple entrypoints in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN make build
 # The second stage container, for running the application
 # -----------------------------------------------------------------
 FROM alpine:3.14
-COPY --from=builder /build/bin/sharechat /app/sharechat
+COPY --from=builder /build/bin /app
 COPY --from=builder /build/migrations /app/migrations
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 build: 
 	go build -ldflags="-s -w" -o bin/sharechat cmd/sharechat/main.go
+	go build -ldflags="-s -w" -o bin/memorychat cmd/memorychat/main.go
 
 clean:
 	rm -rf ./bin Gopkg.lock *.out

--- a/cmd/memorychat/main.go
+++ b/cmd/memorychat/main.go
@@ -21,6 +21,6 @@ func main() {
 
 	server := http.NewServer(controller)
 
-	log.Print("starting server on port 8080")
+	log.Print("starting memorychat server on port 8080")
 	log.Fatal(server.ListenAndServe())
 }

--- a/cmd/sharechat/main.go
+++ b/cmd/sharechat/main.go
@@ -47,6 +47,6 @@ func main() {
 
 	server := http.NewServer(controller)
 
-	log.Print("starting server on port 8080")
+	log.Print("starting sharechat server on port 8080")
 	log.Fatal(server.ListenAndServe())
 }


### PR DESCRIPTION
This PR updates the docker image to be able to run either `sharechat` or `memorychat`