### PR TITLE
handle wildcards, use cors handler logic for upgrader

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,7 +37,7 @@ services:
     build: . 
     command: [
       "--allowed-origin", 
-      "http://localhost:3000",
+      "*",
     ]
     environment:
       POSTGRES_USER: user


### PR DESCRIPTION
Removes buggy check origin logic for the upgrader, uses `cors.OriginAllowed` instead to keep the behavior consistent